### PR TITLE
fix: revise API response for safety

### DIFF
--- a/src/app/api/rating/route.ts
+++ b/src/app/api/rating/route.ts
@@ -33,9 +33,6 @@ export async function GET() {
     originalCompletion: randomRatings[0].originalCompletion,
     editedPrompt: randomRatings[0].editedPrompt,
     editedCompletion: randomRatings[0].editedCompletion,
-    contributorId: randomRatings[0].contributorId,
-    contributorName: contributor?.username,
-    contributorAvatar: contributor?.avatarUrl,
   });
 }
 


### PR DESCRIPTION
Although the contributor ID in response will not be shown on GUI, but to achieve 100% anonymous for public data, it might still be better to remove contributorID in API response.